### PR TITLE
added flexibility of weekends

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2009-2014, Odysseas Tsatalos and contributors.
+Copyright (c) 2009-2015, Odysseas Tsatalos and contributors.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,6 +1,6 @@
-Metadata-Version: 1.4
+Metadata-Version: 1.5
 Name: Workdays
-Version: 1.4
+Version: 1.5
 Summary: Workday date utility functions 
 Home-page: http://github.com/ogt/workdays
 Author: Odysseas Tsatalos

--- a/Readme.md
+++ b/Readme.md
@@ -4,13 +4,13 @@ Workday date utility functions to extend datetime
 
 ## Synopsis
 
-`NETWORKDAYS(start_date,end_date,holidays)`
+`NETWORKDAYS(start_date,end_date,holidays,weekends)`
 
-`WORKDAY(start_date,days,[holidays])`
+`WORKDAY(start_date,days,[holidays],(weekends))`
 
 ## Description
 
-`NETWORKDAYS(start_date,end_date,holidays)`
+`NETWORKDAYS(start_date,end_date,holidays,weekends)`
 
 Returns the number of whole working days between start_date and end_date
 (inclusive of both start_date and end_date). Working days exclude
@@ -24,8 +24,13 @@ Holidays is an optional list of one or more dates to exclude from
 the working calendar, such as state and federal holidays and floating
 holidays. The holiday list should not have duplicates.
 
+Weekends is an optional tuple of integers that correlate to the
+standard weekday numbers which defaults to (5,6) indicating Saturday
+and Sunday.
+
 The function should work almost identically to the corresponding
-Networkdays function of Excel  (Analysis ToolPak)
+Networkdays function of Excel  (Analysis ToolPak) when the default
+weekends (5,6) tuple is not overridden.
 
 Note that just like in excel workday and networks days aren't
 "complimentary"  i..e if wdays = networkdays(d1,d2) you *cannot*
@@ -36,7 +41,7 @@ complimentary. We have followed to obey excel's conventions as opposed
 to come up with our own.  Also start_date has to be less than or equal
 to end_date
 
-`WORKDAY(start_date,days,[holidays])`
+`WORKDAY(start_date,days,[holidays],(weekends))`
 
 Returns a number that represents a date that is the indicated number
 of working days before or after a date (the starting date). Working
@@ -51,6 +56,10 @@ value yields a past date.
 Holidays is an optional list of one or more dates to exclude from
 the working calendar, such as state and federal holidays and floating
 holidays. The holiday list should not have duplicates.
+
+Weekends is an optional tuple of integers that correlate to the
+standard weekday numbers which defaults to (5,6) indicating Saturday
+and Sunday.
 
 The function should work almost identically to the corresponding Workday
 function of Excel  (Analysis ToolPak)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(name='workdays',
-      version='1.4',
+      version='1.5',
       description="Workday date utility functions to extend python's datetime",
       author='Odysseas Tsatalos',
       py_modules=['workdays'],
@@ -24,22 +24,26 @@ setup(name='workdays',
     Extend python datetime with excel-like workday addition/subtraction
     functionality:
 
-    NETWORKDAYS(start_date,end_date,holidays)
+    NETWORKDAYS(start_date,end_date,holidays,weekends)
 
     Returns the number of whole working days between start_date and
     end_date (inclusive of both start_date and end_date). Working days
     exclude weekends and any dates identified in holidays. Use NETWORKDAYS
     to calculate employee benefits that accrue based on the number of
-    days worked during a specific term.
+    days worked during a specific term.  Weekends default to Saturday
+    and Sunday, but can be overridden by passing in a tuple of integers
+    that correlate with the standard weekday numbering.  For example, you
+    can pass in (4,5,6) if you want Friday to be counted as a weekend.
 
-    WORKDAY(start_date,days,[holidays])
+    WORKDAY(start_date,days,[holidays],(weekends))
 
     Returns a number that represents a date that is the indicated number
     of working days before or after a date (the starting date). Working
     days exclude weekends and any dates identified as holidays. Use
     WORKDAY to exclude weekends or holidays when you calculate invoice
     due dates, expected delivery times, or the number of days of work
-    performed.
+    performed.  Like NETWORKDAYS, weekends default to Saturday and Sunday
+    but this can be overridden.
 
     This module has similarities with the BusinessHours module - you may
     want to check it out as well to see which one better fits your needs.

--- a/test_all.py
+++ b/test_all.py
@@ -2,6 +2,7 @@
 
 from datetime import date
 from workdays import workday
+from workdays import networkdays
 
 
 def test_monday():
@@ -39,3 +40,54 @@ def test_saturday():
     assert workday(date(2014, 2, 22), 5) == date(2014, 2, 28)
 
     assert workday(date(2014, 2, 22), 6) == date(2014, 3, 3)
+
+
+def test_workday():
+    holidays = [date(2015, 9, 7)]
+    weekends = (0,5,6)
+
+    # test 0 days (so that it act the same as Excel)
+    assert workday(date(2015, 8, 23)) == date(2015, 8, 23)
+    assert workday(date(2015, 8, 23), weekends=weekends) == date(2015, 8, 23)
+
+    # test with non-zero day on weekend
+    assert workday(date(2015, 8, 23), days=1, weekends=weekends) == \
+        date(2015, 8, 25)
+
+    # test with holiday
+    assert workday(date(2015, 9, 4), days=1, holidays=holidays) == \
+        date(2015, 9, 8)
+
+    # test non-zero workday solo, with holidays, with weekends, and both
+    assert workday(date(2015, 8, 24), 10) == date(2015, 9, 7)
+    assert workday(date(2015, 8, 25), 10, weekends=weekends) == \
+        date(2015, 9, 10)
+    assert workday(date(2015, 8, 24), 10, holidays=holidays) == \
+        date(2015, 9, 8)
+    assert workday(date(2015, 8, 25), 10, holidays=holidays,
+        weekends=weekends) == date(2015, 9, 10)
+
+
+def test_networkdays():
+    # test standard networkdays with no holidays or modified weekend
+    assert networkdays(date(2015, 8, 1), date(2015, 9, 30), holidays=[]) == 43
+
+    # test with USA's Labor Day
+    holidays = [date(2015, 9, 7)]
+    assert networkdays(date(2015, 8, 1), date(2015, 9, 30),
+        holidays=holidays) == 42
+
+    # test with short work week (Friday's off as well)
+    weekends = (4,5,6)
+    assert networkdays(date(2015, 8, 1), date(2015, 9, 30), holidays=[],
+        weekends=weekends) == 35
+
+    # test with holidays and short work week
+    weekends = (4,5,6)
+    assert networkdays(date(2015, 8, 1), date(2015, 9, 30), holidays=holidays,
+        weekends=weekends) == 34
+
+    # test with overlapping holiday and weekend
+    weekends = (0,5,6)
+    assert networkdays(date(2015, 8, 1), date(2015, 9, 30), holidays=holidays,
+        weekends=weekends) == 34

--- a/workdays.py
+++ b/workdays.py
@@ -5,10 +5,12 @@ from datetime import timedelta
 
 # Define the weekday mnemonics to match the date.weekday function
 (MON, TUE, WED, THU, FRI, SAT, SUN) = range(7)
-weekends=(SAT,SUN)
+# Define default weekends, but allow this to be overridden at the function level
+# in case someone only, for example, only has a 4-day workweek.
+default_weekends=(SAT,SUN)
 
 
-def networkdays(start_date, end_date, holidays=[]):
+def networkdays(start_date, end_date, holidays=[], weekends=default_weekends):
     delta_days = (end_date - start_date).days + 1
     full_weeks, extra_days = divmod(delta_days, 7)
     # num_workdays = how many days/week you work * total # of weeks
@@ -31,7 +33,7 @@ def _in_between(a,b,x):
 def cmp(a, b):
     return (a > b) - (a < b)
 
-def workday(start_date, days=0, holidays=[]):
+def workday(start_date, days=0, holidays=[], weekends=default_weekends):
     if days== 0:
         return start_date;
     if days>0 and start_date.weekday() in weekends: #


### PR DESCRIPTION
I found a use case where I needed to define weekends as something other than Saturday and Sunday.  therefore, I've gone ahead and allowed the default `(5,6)` tuple to be overridden with any tuple at the `networkdays` and `workday` function level via a `kwarg`.

I updated the tests accordingly and also added coverage for `networkdays` in general which was not there before.